### PR TITLE
Replace building_name with lab_name in LabAPI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ small_dict = laundry.get_status_simple(building_name="TOWERS")
 lab = LabAPI()
 # Will return a dictionary with status of the lab, and amount
 # of machines with a certain OS
-small_dict = lab.get_status(building_name="ALUMNI")
+small_dict = lab.get_status(lab_name="ALUMNI")
 ```
 
 ### TODO  

--- a/pittAPI.py
+++ b/pittAPI.py
@@ -152,20 +152,20 @@ class LabAPI:
     def __init__(self):
         pass
 
-    def get_status(self, building_name):
+    def get_status(self, lab_name):
         """
         :returns: a dictionary with status and amount of OS machines.
 
-        :param: building_name: Building name
+        :param: lab_name: Lab name
         """
 
-        building_name = building_name.upper()
+        lab_name = lab_name.upper()
         url = 'http://www.ewi-ssl.pitt.edu/labstats_txtmsg/'
         page = urllib2.urlopen(url)
         soup = BeautifulSoup(page.read())
         labs = soup.span.contents[0].strip().split("  ")
 
-        lab = labs[self.location_dict[building_name]].split(':')
+        lab = labs[self.location_dict[lab_name]].split(':')
         di = {}
         if len(lab) > 1:
             lab = [x.strip() for x in lab[1].split(',')]


### PR DESCRIPTION
The strings used to identify labs aren't necessarily buildings, specifically `CATH_G26` and `CATH_G27`.