### PR TITLE
Change quote marks for the cURL calls

### DIFF
--- a/pittAPI.py
+++ b/pittAPI.py
@@ -241,7 +241,7 @@ class LaundryAPI:
     def get_status_detailed(self, building_name):
 
         # Get a cookie
-        cookie_cmd = "curl -I -s 'http://www.laundryview.com/laundry_room.php?view=c&lr={}'".format(
+        cookie_cmd = "curl -I -s \"http://www.laundryview.com/laundry_room.php?view=c&lr={}\"".format(
             self.location_dict[building_name])
 
         response = subprocess.check_output(cookie_cmd, shell=True)
@@ -250,7 +250,7 @@ class LaundryAPI:
 
         # Get the weird laundry data
         cmd = """
-        curl -s 'http://www.laundryview.com/dynamicRoomData.php?location={}' -H 'Cookie: PHPSESSID={}' --compressed
+        curl -s "http://www.laundryview.com/dynamicRoomData.php?location={}" -H "Cookie: PHPSESSID={}" --compressed
         """.format(self.location_dict[building_name], cookie)
 
         response = subprocess.check_output(cmd, shell=True)


### PR DESCRIPTION
On Windows machines, the Python interpreter changes apostrophes (') to backticks (`) when making a command line call, and the Windows port of curl hates it.
I've turned instance of apostrophes with the cURL call into quotation marks (") and escaped quotation marks (\") where necessary, and the error messages left.
This affects 3 lines of code.